### PR TITLE
Make send.mail tolerant of more error types

### DIFF
--- a/R/mailR.R
+++ b/R/mailR.R
@@ -255,6 +255,7 @@ send.mail <- function(from, to, subject = "", body = "", encoding = "iso-8859-1"
                  stop(paste(class(e)[1], e$jobj$getMessage(), sep = " (Java): "), call. = FALSE)
                } else 
                  stop("Undefined error occurred! Turn debug mode on to see more details.")
-             }
+             },
+             error = function(e) message(e)
   )
 }


### PR DESCRIPTION
Hi Raj

I have found that some errors can halt execution of non-interactive R (ie in RScript.exe) processes that use send.mail.  Stepping through the code, it seems your .jTryCatch should have an 'error' handler as well as a 'Throwable' one.

In this pull request is the suggested change.

Charles