### PR TITLE
change behavior of 'html' argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: A Utility to Send Emails from R
 Description: Interface to Apache Commons Email to send emails
     from R.
-Version: 0.5
+Version: 0.6
 Date: 2015-12-06
 Author: Rahul Premraj
 Maintainer: Rahul Premraj <r.premraj+mailR@gmail.com>

--- a/R/mailR.R
+++ b/R/mailR.R
@@ -211,9 +211,9 @@ send.mail <- function(from, to, subject = "", body = "", encoding = "iso-8859-1"
   if(html)
   {
     email$setHtmlMsg(as.character(body))
-    email$setTextMsg("Your email client does not support HTML messages")
+    email$setTextMsg(.stripHTML(body))
   } else
-    email$setMsg(paste("The contents of the original email have been modified because your email client does not support viewing HTML emails.", .stripHTML(body), sep = "\n\n"))
+    email$setMsg(body)
 
   if(.valid.email(to))
     sapply(to, email$addTo)

--- a/R/mailR.R
+++ b/R/mailR.R
@@ -236,6 +236,12 @@ send.mail <- function(from, to, subject = "", body = "", encoding = "iso-8859-1"
       sapply(dots$replyTo, email$addReplyTo)
   }
 
+  if ("headers" %in% names(dots))
+  {
+    lapply(names(dots$headers), function(x)
+      email$addHeader(x, dots$headers[[x]]))
+  }
+
   if(send)
     .jTryCatch(email$send())
 


### PR DESCRIPTION
If a user is sending plain-text (non-html) emails, the emails do not need to say "The contents of the original email have been modified...". And similarly, we do not need to strip out HTML tags from the plain text email, because if the user specified `html=FALSE` when invoking `send.mail()`, we can assume they want any HTML tags in the email body to be sent as part of the plain text.

Conversely, if `html=TRUE`, then we should not set the plain text component of the message to be "Your email client does not support HTML messages".
For example, with the Zimbra Web Client, in the preview pane where it pulls out the first few words of the email for easy viewing, it shows this error message but it should show the text of the email:

![mailpreviewzimbra](https://cloud.githubusercontent.com/assets/2286826/11985816/8c2e43bc-a97d-11e5-82a3-4d861ff00830.jpg)

This could be an issue with this particular client, but anyway, this fixes it. So now the "text" portion of an HTML message is set to `.stripHTML(body)`.

Thanks for a very useful package.