### PR TITLE
headers generated from named list ('headers' arg to send.mail())

### DIFF
--- a/R/mailR.R
+++ b/R/mailR.R
@@ -236,6 +236,12 @@ send.mail <- function(from, to, subject = "", body = "", encoding = "iso-8859-1"
       sapply(dots$replyTo, email$addReplyTo)
   }
 
+  if ("headers" %in% names(dots))
+  {
+    lapply(names(dots$headers), function(x)
+      email$addHeader(x, dots$headers[[x]]))
+  }
+
   if(send)
     .jTryCatch(email$send())
 


### PR DESCRIPTION
If a named list called  `headers` is passed to `send.mail()`, this adds the headers to the email.
Example:

```
headers=list("X-Foo-Bar"="foobar","X-Header2"="some value")
```

Will result in an email that has these additional headers:

```
X-Foo-Bar: foobar
X-Header2: some value
```

I find this feature useful because I often want to set up rules in my mail client for processing the emails that are sent programmatically. I can set up rules based on the presence of certain headers, and then I don't have to depend on the content or the subject line containing some specific value. I can imagine other use cases (for example, you want to tag every email with "X-Sent-By: My Awesome Program" or something).

